### PR TITLE
Title accepts null values

### DIFF
--- a/src/CodeReview.Evaluator/Resources/IssueDbScript.sql
+++ b/src/CodeReview.Evaluator/Resources/IssueDbScript.sql
@@ -2,7 +2,7 @@
 	"Id"	INTEGER,
 	"RuleId"	TEXT NOT NULL,
 	"Level"	TEXT NOT NULL,
-	"Title"	TEXT NOT NULL,
+	"Title"	TEXT,
 	"Message"	TEXT NOT NULL,
 	"Description"	TEXT,
 	"DetailsUrl"	TEXT,

--- a/src/CodeReview.Evaluator/Services/DatabaseService.cs
+++ b/src/CodeReview.Evaluator/Services/DatabaseService.cs
@@ -339,7 +339,7 @@ namespace GodelTech.CodeReview.Evaluator.Services
 
             issueCommand.Parameters.AddWithValue("$ruleId", issue.RuleId);
             issueCommand.Parameters.AddWithValue("$level", issue.Level);
-            issueCommand.Parameters.AddWithValue("$title", issue.Title);
+            issueCommand.Parameters.AddWithValue("$title", (object)issue.Title ?? DBNull.Value);
             issueCommand.Parameters.AddWithValue("$message", issue.Message);
             issueCommand.Parameters.AddWithValue("$description", (object) issue.Description ?? DBNull.Value);
             issueCommand.Parameters.AddWithValue("$detailsUrl", (object) issue.DetailsUrl ?? DBNull.Value);


### PR DESCRIPTION
+semver:patch

#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [x] Patch

#### GITHUB ISSUE LINK
Roslyn issues may not have title. This might be issues generated by C# compiler. Existing code was updated to accept `null` value for `Title` field.