### PR TITLE
[bug]: fixed check for empty result in DatabaseService

### DIFF
--- a/src/CodeReview.Evaluator/Services/DatabaseService.cs
+++ b/src/CodeReview.Evaluator/Services/DatabaseService.cs
@@ -155,7 +155,7 @@ namespace GodelTech.CodeReview.Evaluator.Services
 
             await using var reader = await command.ExecuteReaderAsync();
 
-            if (!reader.Read())
+            if (!reader.HasRows)
                 return null;
 
             var schema = reader.GetSchemaTable();


### PR DESCRIPTION
#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [ ] Major
 - [ ] Minor
 - [x] Patch

#### GITHUB ISSUE LINK
None

#### ERROR:
When using Type: Collection the first row will be skipped.

#### HOW TO REPRODUCE:
1. Create manifest like the following
```yaml
equests:
  simpleSelect:
    query: SELECT * FROM Table ORDER BY ???
    type: Collection
```
2. Run `dotnet run evaluate -o result.json -m manifest.yaml -d database.db`
3. I see that the `simpleSelect` property is missing the first row that presents if I run the query manually

#### ROOT CAUSE:
The following check on empty result reads the first row, so the following while loop will be started from the second element.
```csharp
if (!reader.Read()) <--- causes the error 
    return null;

var schema = reader.GetSchemaTable();
var results = new List<Dictionary<string, object>>();
while (reader.Read())
{
    results.Add(ReadObject(schema, reader));
}
```